### PR TITLE
fix flickering pending tx page

### DIFF
--- a/src/tx/index.tsx
+++ b/src/tx/index.tsx
@@ -46,6 +46,7 @@ interface TxProps {
 
 export const Tx: React.FunctionComponent<TxProps> = ({ id }) => {
   const [tx, setTx] = useState<TxInterface>();
+  const [initialised, setInitialised] = useState<boolean>(false);
 
   const { get, response, loading, error } = useFetch();
 
@@ -56,7 +57,9 @@ export const Tx: React.FunctionComponent<TxProps> = ({ id }) => {
 
   // init
   useEffect(() => {
-    fetchTx(id).catch(() => `Error fetching tx details: ${id}`);
+    fetchTx(id)
+      .catch(() => `Error fetching tx details: ${id}`)
+      .finally(() => setInitialised(true));
   }, []);
 
   useEffect(() => {
@@ -89,7 +92,7 @@ export const Tx: React.FunctionComponent<TxProps> = ({ id }) => {
 
   const txTitleNode = <StyledSectionTitle breadcrumbs={breadcrumbs} />;
 
-  if (loading || !tx) {
+  if ((loading || !tx) && !initialised) {
     return (
       <Sections>
         <Section title={txTitleNode}>


### PR DESCRIPTION
# Description

don't display `loading` placeholder when polling, if tx data has already been fetched

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
